### PR TITLE
Special mconcat, mconcat benchmarks, intercalate

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -1,0 +1,17 @@
+import Gauge.Main (defaultMain, bench, whnf)
+
+import Data.Bytes.Types
+import Data.List (permutations)
+import qualified Data.Bytes as Bytes
+
+naiveMconcat :: [Bytes] -> Bytes
+naiveMconcat = foldr mappend mempty
+
+main :: IO ()
+main = defaultMain
+  [ bench "mconcat" $ whnf mconcat mconcatBytes
+  , bench "naiveMconcat" $ whnf naiveMconcat mconcatBytes
+  ]
+
+mconcatBytes :: [Bytes]
+mconcatBytes = fmap Bytes.fromAsciiString $ permutations ['a'..'g']

--- a/byteslice.cabal
+++ b/byteslice.cabal
@@ -54,3 +54,15 @@ test-suite test
     , tasty
     , tasty-hunit
     , tasty-quickcheck
+
+benchmark bench
+  type: exitcode-stdio-1.0
+  build-depends:
+    , base
+    , byteslice
+    , gauge
+    , primitive
+  ghc-options: -Wall -O2
+  default-language: Haskell2010
+  hs-source-dirs: bench
+  main-is: Main.hs

--- a/src/Data/Bytes.hs
+++ b/src/Data/Bytes.hs
@@ -51,6 +51,8 @@ module Data.Bytes
   , split2
   , split3
   , split4
+    -- * Combining
+  , intercalate
     -- * Counting
   , Byte.count
     -- * Prefix and Suffix
@@ -117,6 +119,7 @@ import GHC.Word (Word8(W8#))
 import System.IO (Handle)
 
 import qualified Data.Bytes.Byte as Byte
+import qualified Data.List as List
 import qualified Data.Primitive as PM
 import qualified Data.Primitive.Ptr as PM
 import qualified GHC.Exts as Exts
@@ -715,3 +718,8 @@ touchByteArrayIO (ByteArray x) =
 touchMutableByteArrayIO :: MutableByteArray s -> IO ()
 touchMutableByteArrayIO (PM.MutableByteArray x) =
   IO (\s -> (# Exts.touch# x s, () #))
+
+-- | /O(n)/ The intercalate function takes Bytes and a list of Bytes and concatenates the list after interspersing the first argument between each element of the list.
+intercalate :: Bytes -> [Bytes] -> Bytes
+intercalate s = mconcat . List.intersperse s
+


### PR DESCRIPTION
```
1 of 1 test suites (1 of 1 test cases) passed.
```
```
benchmarked mconcat
time                 61.45 μs   (60.11 μs .. 62.88 μs)
                     0.997 R²   (0.996 R² .. 0.998 R²)
mean                 60.51 μs   (60.12 μs .. 60.99 μs)
std dev              1.512 μs   (1.262 μs .. 1.758 μs)

benchmarked naiveMconcat
time                 6.451 ms   (6.402 ms .. 6.516 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 6.499 ms   (6.471 ms .. 6.537 ms)
std dev              99.59 μs   (73.52 μs .. 145.7 μs)
```