### PR TITLE
Add a flag to control avoidance of rawmemchr

### DIFF
--- a/byteslice.cabal
+++ b/byteslice.cabal
@@ -17,6 +17,10 @@ copyright: 2019 Andrew Martin
 category: Data
 extra-source-files: CHANGELOG.md
 
+flag avoid-rawmemchr
+    default: true
+    description: Avoid using rawmemchr which is non-portable GNU libc only
+
 library
   exposed-modules:
     Data.Bytes
@@ -50,6 +54,8 @@ library
   includes: bs_custom.h
   install-includes: bs_custom.h
   c-sources: cbits/bs_custom.c
+  if flag(avoid-rawmemchr)
+    cc-options: -DAVOID_RAWMEMCHR=1
 
 test-suite test
   default-language: Haskell2010

--- a/cbits/bs_custom.c
+++ b/cbits/bs_custom.c
@@ -19,7 +19,7 @@ HsInt memchr_ba_many(unsigned char *p, HsInt off, HsInt len, HsInt *sizes, HsInt
   p = p + off;
   total = 0;
   for (szIx = 0; szIx < sizesLen; ++szIx) {
-#ifdef __linux__
+#if defined(__linux__) && !AVOID_RAWMEMCHR
     pos = (unsigned char*)(rawmemchr((void*)p,(int)w));
     delta = (HsInt)(pos - p);
 #else


### PR DESCRIPTION
Fix #3 

Adds a flag to avoid use of `rawmemchr` which is glibc only and breaks OSX, Windows, Linux Alpine, Linux using non glibc in general.