### PR TITLE
Bump `vector` Upper Bounds

### DIFF
--- a/byteslice.cabal
+++ b/byteslice.cabal
@@ -48,7 +48,7 @@ library
     , run-st >=0.1.1 && <0.2
     , text-short >=0.1.3 && <0.2
     , tuples >=0.1 && <0.2
-    , vector >=0.12 && <0.13
+    , vector >=0.12 && <0.14
   hs-source-dirs: src
   ghc-options: -Wall -O2
   if impl(ghc>=9.2)


### PR DESCRIPTION
Bump upper-bounds for `vector` to `<0.14`. Needed to keep `byteslice` in Stackage Nightly: https://github.com/commercialhaskell/stackage/issues/6624

Tested on ghc 9.0 with:
```sh
cabal new-test --disable-documentation --constraint 'vector>=0.13' 
```

Tested on ghc 9.2 with ghcup:
```sh
cabal-3.6.2.0 new-test --disable-documentation --constraint 'vector>=0.13' -w ghc-9.2.3
```