### PR TITLE
build: fix lower bound of primitive: 0.7 → 0.7.4

### DIFF
--- a/byteslice.cabal
+++ b/byteslice.cabal
@@ -43,7 +43,7 @@ library
   build-depends:
     , base >=4.14 && <5
     , bytestring >=0.10.8 && <0.12
-    , primitive >=0.7 && <0.8
+    , primitive >=0.7.4 && <0.8
     , primitive-unlifted >=0.1.2 && <0.2
     , primitive-addr >=0.1 && <0.2
     , run-st >=0.1.1 && <0.2


### PR DESCRIPTION
This avoids build errors due to `copyPtrToMutablePrimArray`,which was exposed in 0.7.4.0:

https://github.com/haskell/primitive/blob/master/changelog.md#changes-in-version-0740