### PR TITLE
build with primitive 0.8

### DIFF
--- a/byteslice.cabal
+++ b/byteslice.cabal
@@ -43,7 +43,7 @@ library
   build-depends:
     , base >=4.14 && <5
     , bytestring >=0.10.8 && <0.12
-    , primitive >=0.7.4 && <0.8
+    , primitive >=0.7.4 && <0.9
     , primitive-unlifted >=0.1.2 && <0.2
     , primitive-addr >=0.1 && <0.2
     , run-st >=0.1.1 && <0.2


### PR DESCRIPTION
```
❯ cabal build --constraint="primitive == 0.8.0.0" --allow-newer=primitive-unlifted:primitive --allow-newer=primitive-addr:primitive --allow-newer=run-st:primitive --allow-newer=tuples:primitive
Resolving dependencies...
Build profile: -w ghc-9.4.4 -O1
In order, the following will be built (use -v for more details):
 - primitive-addr-0.1.0.2 (lib) (requires build)
 - run-st-0.1.1.0 (lib) (requires build)
 - tuples-0.1.0.0 (lib) (requires build)
 - vector-0.13.0.0 (lib) (requires build)
 - byteslice-0.2.9.0 (lib) (first run)
Starting     primitive-addr-0.1.0.2 (lib)
Starting     run-st-0.1.1.0 (lib)
Starting     tuples-0.1.0.0 (lib)
Starting     vector-0.13.0.0 (lib)
Building     run-st-0.1.1.0 (lib)
Building     tuples-0.1.0.0 (lib)
Building     primitive-addr-0.1.0.2 (lib)
Building     vector-0.13.0.0 (lib)
Installing   run-st-0.1.1.0 (lib)
Installing   primitive-addr-0.1.0.2 (lib)
Completed    run-st-0.1.1.0 (lib)
Completed    primitive-addr-0.1.0.2 (lib)
Installing   tuples-0.1.0.0 (lib)
Completed    tuples-0.1.0.0 (lib)
Installing   vector-0.13.0.0 (lib)
Completed    vector-0.13.0.0 (lib)
Configuring library for byteslice-0.2.9.0..
Preprocessing library for byteslice-0.2.9.0..
Building library for byteslice-0.2.9.0..
[ 1 of 16] Compiling Cstrlen          ( src-ghc-cstrlen/Cstrlen.hs, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Cstrlen.o, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Cstrlen.dyn_o )
[ 2 of 16] Compiling Data.Bytes.Internal ( src/Data/Bytes/Internal.hs, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Internal.o, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Internal.dyn_o )
[ 3 of 16] Compiling Data.Bytes.Text.Windows1252 ( src/Data/Bytes/Text/Windows1252.hs, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Text/Windows1252.o, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Text/Windows1252.dyn_o )
[ 4 of 16] Compiling Reps             ( src-new-reps/Reps.hs, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Reps.o, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Reps.dyn_o )
[ 5 of 16] Compiling Data.Bytes.Types ( src/Data/Bytes/Types.hs, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Types.o, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Types.dyn_o )
[ 6 of 16] Compiling Data.Bytes.Pure  ( src/Data/Bytes/Pure.hs, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Pure.o, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Pure.dyn_o )
[ 7 of 16] Compiling Data.Bytes.Text.Latin1 ( src/Data/Bytes/Text/Latin1.hs, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Text/Latin1.o, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Text/Latin1.dyn_o )
[ 8 of 16] Compiling Data.Bytes.Text.AsciiExt ( src/Data/Bytes/Text/AsciiExt.hs, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Text/AsciiExt.o, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Text/AsciiExt.dyn_o )
[ 9 of 16] Compiling Data.Bytes.Text.Ascii ( src/Data/Bytes/Text/Ascii.hs, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Text/Ascii.o, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Text/Ascii.dyn_o )
[10 of 16] Compiling Data.Bytes.Mutable ( src/Data/Bytes/Mutable.hs, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Mutable.o, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Mutable.dyn_o )
[11 of 16] Compiling Data.Bytes.IO    ( src/Data/Bytes/IO.hs, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/IO.o, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/IO.dyn_o )
[12 of 16] Compiling Data.Bytes.Byte  ( src/Data/Bytes/Byte.hs, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Byte.o, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Byte.dyn_o )
[13 of 16] Compiling Data.Bytes.Search ( src/Data/Bytes/Search.hs, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Search.o, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Search.dyn_o )
[14 of 16] Compiling Data.Bytes.Chunks ( src/Data/Bytes/Chunks.hs, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Chunks.o, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Chunks.dyn_o )
[15 of 16] Compiling Data.Bytes       ( src/Data/Bytes.hs, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes.o, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes.dyn_o )
[16 of 16] Compiling Data.Bytes.Text.Utf8 ( src/Data/Bytes/Text/Utf8.hs, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Text/Utf8.o, /home/chessai/haskell/byteslice/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byteslice-0.2.9.0/build/Data/Bytes/Text/Utf8.dyn_o )
```